### PR TITLE
Enhance wrong answer tracking by preventing duplicates in QuizContext

### DIFF
--- a/src/context/QuizContext.tsx
+++ b/src/context/QuizContext.tsx
@@ -30,8 +30,14 @@ export const QuizProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         setWrongQuestions([]);
     };
 
-    const addWrongQuestion = (question: WrongQuestion) => {
-        setWrongQuestions((prev) => [...prev, question]);
+    const addWrongQuestion = (wrongAnswer: WrongQuestion) => {
+        setWrongQuestions((prev) => {
+            const isAnswerAlreadyRecorded = prev.some((q) => q.question === wrongAnswer.question);
+            if (!isAnswerAlreadyRecorded) {
+                return [...prev, wrongAnswer];
+            }
+            return prev;
+        })
     };
 
     return (


### PR DESCRIPTION
Modifies the `addWrongQuestion` function in the QuizContext to prevent duplicate wrong answers from being recorded.

## Changes Made
- Updated `addWrongQuestion` to check if a question is already recorded before adding it
- Added validation using `some()` to check for existing questions
- Improved parameter naming from `question` to `wrongAnswer` for better clarity

Screenshots from production:
![image](https://github.com/user-attachments/assets/86c1e057-59ae-4b0c-b43c-381be144b999)
![image](https://github.com/user-attachments/assets/39e44125-77a0-498f-8ad6-305d33bc4844)